### PR TITLE
Add table of contents to What's New page

### DIFF
--- a/_includes/releases/r179.html
+++ b/_includes/releases/r179.html
@@ -1,12 +1,27 @@
 <p>Updated to Vim 9.1.0</p>
 
+<nav>
+<ul class="toc" id="markdown-toc">
+  <li><a href="#r179-features" id="markdown-toc-r179-features">Features</a>    <ul>
+      <li><a href="#r179-system-monospace-font-sf-mono" id="markdown-toc-r179-system-monospace-font-sf-mono">System monospace font (SF Mono)</a></li>
+      <li><a href="#r179-new-vim-features" id="markdown-toc-r179-new-vim-features">New Vim features</a></li>
+      <li><a href="#r179-misc" id="markdown-toc-r179-misc">Misc</a></li>
+    </ul>
+  </li>
+  <li><a href="#r179-general" id="markdown-toc-r179-general">General</a></li>
+  <li><a href="#r179-fixes" id="markdown-toc-r179-fixes">Fixes</a></li>
+  <li><a href="#r179-compatibility" id="markdown-toc-r179-compatibility">Compatibility</a></li>
+</ul>
+
+</nav>
+
 <p>Happy New Year! See <a href="https://github.com/macvim-dev/macvim/discussions/1472">#1472</a> for a retrospective of 2023 and future roadmap.</p>
 
 <p>Also, Vim 9.1 is now released! See <a href="https://www.vim.org/vim-9.1-released.php">announcement</a>.</p>
 
-<h1 id="features">Features</h1>
+<h1 id="r179-features">Features</h1>
 
-<h2 id="system-monospace-font-sf-mono">System monospace font (SF Mono)</h2>
+<h2 id="r179-system-monospace-font-sf-mono">System monospace font (SF Mono)</h2>
 
 <p>MacVim’s <code>guifont</code> option now supports a new <code>-monospace-</code> value, which instructs it to use the system monospace font, which is SF Mono in recent macOS versions. As mentioned below (New Vim features), you can now use tab-completion to see the available values in cmdline. See <a href="https://macvim.org/docs/redirect.html?tag=macvim-guifont"><code>:h macvim-guifont</code></a> for more details on how to use it (including using different font weights). <a href="https://github.com/macvim-dev/macvim/issues/1463">#1463</a></p>
 
@@ -14,7 +29,7 @@
 
 <p><img width="310" alt="Menlo (default) vs SF Mono" src="https://github.com/macvim-dev/macvim/assets/1217449/56e4a7b7-9f9d-4cfa-9e6a-bb4baffc6d30" /></p>
 
-<h2 id="new-vim-features">New Vim features</h2>
+<h2 id="r179-new-vim-features">New Vim features</h2>
 
 <ul>
   <li>Command-line tab completion improvements and bug fixes (see <a href="https://macvim.org/docs/redirect.html?tag=cmdline-completion"><code>:h cmdline-completion</code></a> and <a href="https://macvim.org/docs/redirect.html?tag=complete-set-option"><code>:h complete-set-option</code></a>)
@@ -41,7 +56,7 @@
   <li>Miscellaneous security fixes.</li>
 </ul>
 
-<h2 id="misc">Misc</h2>
+<h2 id="r179-misc">Misc</h2>
 
 <p>New settings:</p>
 
@@ -56,7 +71,7 @@
   <li>MacVim can be launched without loading user defaults for a clean experience via a command-line flag. See <a href="https://macvim.org/docs/redirect.html?tag=macvim-settings"><code>:h macvim-settings</code></a>.</li>
 </ul>
 
-<h1 id="general">General</h1>
+<h1 id="r179-general">General</h1>
 
 <ul>
   <li>Sparkle (updater for MacVim) is now updated to 2.5.2. The updater can now show multiple release notes when updating MacVim across multiple versions. <a href="https://github.com/macvim-dev/macvim/issues/1446">#1446</a> <a href="https://github.com/macvim-dev/macvim/issues/1469">#1469</a></li>
@@ -70,14 +85,14 @@
   <li>Python 2 support: The default location for locating the Python 2 lib in the binary release is now under /Library/Frameworks rather than /usr/local. Note: Python 2 has long been obsolete. If you rely on Python 2 plugins, consider this a warning as it’s only supported as long as it’s feasible and could be removed in the future. <a href="https://github.com/macvim-dev/macvim/issues/1434">#1434</a></li>
 </ul>
 
-<h1 id="fixes">Fixes</h1>
+<h1 id="r179-fixes">Fixes</h1>
 
 <ul>
   <li>Fixed non-native full screen mode when using a MacBook with a notch and having the “Show menu bar in non-native mode” option set. Changing the screen resolution while using non-native full screen also works properly now. <a href="https://github.com/macvim-dev/macvim/issues/1450">#1450</a></li>
   <li>Fixed Help menu’s documentation search not working with tags with special characters like <code>&lt;Down&gt;</code>. <a href="https://github.com/macvim-dev/macvim/issues/1455">#1455</a></li>
 </ul>
 
-<h1 id="compatibility">Compatibility</h1>
+<h1 id="r179-compatibility">Compatibility</h1>
 
 <p>Requires macOS 10.9 or above. (10.9 - 10.12 requires downloading a separate legacy build)</p>
 

--- a/_includes/releases/r180.html
+++ b/_includes/releases/r180.html
@@ -1,10 +1,24 @@
 <p>Updated to Vim 9.1.0727</p>
 
+<nav>
+<ul class="toc" id="markdown-toc">
+  <li><a href="#r180-features" id="markdown-toc-r180-features">Features</a>    <ul>
+      <li><a href="#r180-new-vim-features" id="markdown-toc-r180-new-vim-features">New Vim features</a></li>
+      <li><a href="#r180-misc" id="markdown-toc-r180-misc">Misc</a></li>
+    </ul>
+  </li>
+  <li><a href="#r180-general" id="markdown-toc-r180-general">General</a></li>
+  <li><a href="#r180-fixes" id="markdown-toc-r180-fixes">Fixes</a></li>
+  <li><a href="#r180-compatibility" id="markdown-toc-r180-compatibility">Compatibility</a></li>
+</ul>
+
+</nav>
+
 <p>This update mostly syncs to new upstream Vim version, along with small fixes.</p>
 
-<h1 id="features">Features</h1>
+<h1 id="r180-features">Features</h1>
 
-<h2 id="new-vim-features">New Vim features</h2>
+<h2 id="r180-new-vim-features">New Vim features</h2>
 
 <ul>
   <li>Vim now supports the XDG Base Directory Specification. You can now put your vimrc and plugins in <code>~/.config/vim</code> intsead of <code>~/.vim</code> / <code>~/.vimrc</code>. See <a href="https://macvim.org/docs/redirect.html?tag=xdg-base-dir"><code>:h xdg-base-dir</code></a>. <a href="https://github.com/vim/vim/commit/c9df1fb35a1866901c32df37dd39c8b39dbdb64a">v9.1.0327</a></li>
@@ -49,26 +63,26 @@
   </li>
 </ul>
 
-<h2 id="misc">Misc</h2>
+<h2 id="r180-misc">Misc</h2>
 
 <ul>
   <li>When resizing MacVim, the title bar’s message looks a little nicer now. <a href="https://github.com/macvim-dev/macvim/issues/1488">#1488</a> by @sfsam</li>
   <li>Copyright disclaimer in About MacVim no longer shows a year. <a href="https://github.com/macvim-dev/macvim/issues/1497">#1497</a></li>
 </ul>
 
-<h1 id="general">General</h1>
+<h1 id="r180-general">General</h1>
 
 <ul>
   <li>Sparkle (updater for MacVim) is now updated to 2.6.4. For legacy builds it’s now updated to 1.27.3.  <a href="https://github.com/macvim-dev/macvim/issues/1494">#1494</a></li>
 </ul>
 
-<h1 id="fixes">Fixes</h1>
+<h1 id="r180-fixes">Fixes</h1>
 
 <ul>
   <li>Fixed dragging tabs to reorder them resulting in a crash. <a href="https://github.com/macvim-dev/macvim/issues/1499">#1499</a></li>
 </ul>
 
-<h1 id="compatibility">Compatibility</h1>
+<h1 id="r180-compatibility">Compatibility</h1>
 
 <p>Requires macOS 10.9 or above. (10.9 - 10.12 requires downloading a separate legacy build)</p>
 

--- a/release-notes/whatsnew.html
+++ b/release-notes/whatsnew.html
@@ -14,6 +14,7 @@
 
     Use ?from=<rev_exclusive>&to=<rev_inclusive> to list a range of releases.
     Use ?version=<rev> to list a single release from its revision number.
+    Use ?all to just show all of them.
     -->
 
     <style>
@@ -71,9 +72,101 @@
       display: block;
     }
 
+    /* TOC */
+    html {
+        scroll-behavior: smooth;
+    }
+    .toc {
+        display: none;
+        border-left: 1px solid darkgray;
+    }
+    .toc a {
+        color: inherit;
+        text-decoration: none;
+    }
+    .toc a:hover {
+        color: #599A42;
+        text-decoration: underline;
+    }
+    @media (prefers-color-scheme: dark) {
+      .toc {
+        border-left: 1px solid dimgray;
+      }
+      .toc a:hover {
+          color: rgb(48,209,88);
+      }
+    }
+    #hidetoc-btn {
+        display: none;
+    }
+    #hidetoc-toggle {
+        display: none;
+    }
+    @media (min-width:50em) {
+        section {
+            width: 72%;
+        }
+        .toc {
+            display: inherit;
+            position: fixed;
+            top: 0;
+            right: 0;
+            width: 24%;
+            max-height: 100%;
+            overflow: auto;
+            padding-left: 1em;
+            margin-left: 1em;
+
+            line-height: 150%;
+            font-size:110%;
+
+            transition: 0.3s;
+        }
+        .toc ul {
+            list-style-type: none;
+            padding-left: 1em;
+        }
+        .toc li {
+            list-style-type: none;
+        }
+
+        #hidetoc-toggle:checked ~ section {
+            width: 95%;
+        }
+        #hidetoc-toggle:checked ~ * .toc {
+            right: -28%;
+            border: none;
+        }
+        #hidetoc-btn {
+            display: inherit;
+            position: fixed;
+            right: 1.5em;
+            z-index: 1;
+            opacity: 0.2;
+        }
+        #hidetoc-btn:hover {
+            opacity: 1.0;
+        }
+        #hidetoc-btn > svg {
+            transition: 0.3s;
+        }
+        #hidetoc-toggle:checked ~ nav > #hidetoc-btn > svg {
+            transform: rotate(180deg);
+        }
+    }
     </style>
   </head>
   <body>
+      <!-- show/hide TOC control -->
+      <input type="checkbox" id="hidetoc-toggle" />
+      <nav>
+        <label for="hidetoc-toggle" id="hidetoc-btn">
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+          </svg>
+        </label>
+      </nav>
+
     {% for release in site.data.releases.prereleases %}
       <section id={{ release }}>
         <header> <h1>MacVim r{{ release }} (prerelease)</h1></header>
@@ -104,9 +197,15 @@
     <script>
       const params = new URLSearchParams(document.location.search);
 
+      let tocs = [];
+
       let fromRev = NaN;
       let toRev = NaN;
-      if (params.has('from') && params.has('to')) {
+      if (params.has('all')) {
+          fromRev = -Infinity;
+          toRev = Infinity;
+      }
+      else if (params.has('from') && params.has('to')) {
         fromRev = parseFloat(params.get('from'));
         toRev = parseFloat(params.get('to'));
       }
@@ -125,12 +224,30 @@
             else {
               sections[i].style.display = 'block';
               foundOne = true;
+
+              let toc = sections[i].querySelector('.toc');
+              if (toc)
+                tocs.push({elem: toc, sectionId: sections[i].id});
             }
           }
         }
         if (!foundOne) {
           document.getElementsByClassName('item-0')[0].style.display = 'block'; // Just show the latest if the input range is not valid so we don't show an empty page
         }
+      }
+      // We have multiple TOCs. We patch it by making a new master list and put every TOC under it.
+      if (tocs.length > 1) {
+          let parentNode = tocs[0].elem.parentNode;
+          let newToc = document.createElement('ul');
+          newToc.className = 'toc';
+          for (var i = 0; i < tocs.length; i++) {
+              tocs[i].elem.className = '';
+              let newTocItem = document.createElement('li');
+              newTocItem.innerHTML = `<a href=#${tocs[i].sectionId}>r${tocs[i].sectionId}</a>`;
+              newTocItem.appendChild(tocs[i].elem);
+              newToc.appendChild(newTocItem);
+          }
+          parentNode.appendChild(newToc);
       }
     </script>
   </body>


### PR DESCRIPTION
Include the relevant styles and a show/hide toggle button on the top right (CSS only). Only show the TOC when the window is wide enough. If there are multiple release notes shown, will automatically group them together into a single TOC in script.

Also add a new "all" parameter that could be passed to the URL parameter which is easier than having to type `?from=1&to=9999`.