### PR TITLE
Support showing multiple releases in appcast

### DIFF
--- a/appcast/_appcast_style.css
+++ b/appcast/_appcast_style.css
@@ -1,4 +1,19 @@
 <style>
 :root { supported-color-schemes: light dark; color-scheme: light dark; }
-h1 { padding-bottom: .3em; border-bottom: 1px solid gray; }
+div h1 { padding-bottom: .3em; border-bottom: 1px solid gray; }
+
+/* Older versions' release notes. Will be optionally shown in collapsed form if the user has upgraded across multiple versions. */
+div > details.oldVersionToggle > summary  {
+  font-size: 1.2em;
+  border-radius: 5px;
+  border-bottom: 3px solid #57c4d0;
+  cursor: pointer;
+  padding: 10px;
+}
+.toc {
+  /* Sparkle does not seem to allow anchor links. Just disable the TOC. */
+  display: none;
+}
+div.sparkle-installed-version { display:none; }
+div.sparkle-installed-version ~ section { display: none; }
 </style>

--- a/appcast/_prerelease.xml
+++ b/appcast/_prerelease.xml
@@ -3,7 +3,9 @@
       <title>MacVim prerelease-180.2</title>
       <description><![CDATA[
 {% include_relative _appcast_style.css %}
+<div>
 {% include releases/r180.2.html %}
+</div>
 <p><br /><small><a href="https://github.com/macvim-dev/macvim/releases/">Latest release notes &gt;</a></small></p>
       ]]></description>
       <sparkle:fullReleaseNotesLink>https://github.com/macvim-dev/macvim/releases</sparkle:fullReleaseNotesLink>

--- a/appcast/_release.xml
+++ b/appcast/_release.xml
@@ -2,7 +2,9 @@
       <title>MacVim release-180</title>
       <description><![CDATA[
 {% include_relative _appcast_style.css %}
+<div>
 {% include releases/r180.html %}
+</div>
 <p><br /><small><a href="https://github.com/macvim-dev/macvim/releases/latest">Latest release notes &gt;</a></small></p>
       ]]></description>
       <sparkle:fullReleaseNotesLink>https://github.com/macvim-dev/macvim/releases</sparkle:fullReleaseNotesLink>

--- a/appcast/_release_legacy.xml
+++ b/appcast/_release_legacy.xml
@@ -2,7 +2,9 @@
       <title>MacVim release-180</title>
       <description><![CDATA[
 {% include_relative _appcast_style.css %}
+<div>
 {% include releases/r180.html %}
+</div>
 <p><br /><small><a href="https://github.com/macvim-dev/macvim/releases/latest">Latest release notes &gt;</a></small></p>
       ]]></description>
       <sparkle:fullReleaseNotesLink>https://github.com/macvim-dev/macvim/releases</sparkle:fullReleaseNotesLink>


### PR DESCRIPTION
MacVim r179 updated Sparkle to 2.5.2, which allows showing mutiple releases notes at once, depending on which version the user is upgrading from. That means we can now show multiple release notes in the appcast now, but only show versions down to r179 (since otherwise it would be confusing to older MacVim users upgrading if they see their own version in the release notes since older Sparkle wouldn't know how to filter them out).

Add the relevant supporting CSS and wrap each include in its own section. The actual change to include multiple releases will be done later.