### PR TITLE
Sign appcast feed

### DIFF
--- a/appcast/_appcast.xml
+++ b/appcast/_appcast.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"> 
+  <channel>
+    <title>MacVim</title>
+    <link>https://macvim.org/appcast/latest.xml</link>
+    <description>MacVim</description>
+{% include_relative _prerelease.xml %}
+{% include_relative _release.xml %}
+{% include_relative _release_legacy.xml %}
+  </channel>
+</rss>

--- a/appcast/_appcast_signature.xml
+++ b/appcast/_appcast_signature.xml
@@ -1,0 +1,4 @@
+<!-- sparkle-signatures:
+edSignature: UwuYxfz+1MxV29U2H25Ojeqdxp6HrHSUmrSEMRAySf/OplUIR1xFS56vCRbbfHFW4erCpkT+0M+J5rDVHGZdBg==
+length: 37463
+-->

--- a/appcast/latest.xml
+++ b/appcast/latest.xml
@@ -1,13 +1,4 @@
 ---
 ---
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"> 
-  <channel>
-    <title>MacVim</title>
-    <link>https://macvim.org/appcast/latest.xml</link>
-    <description>MacVim</description>
-{% include_relative _prerelease.xml %}
-{% include_relative _release.xml %}
-{% include_relative _release_legacy.xml %}
-  </channel>
-</rss>
+{% include_relative _appcast.xml %}
+{% include_relative _appcast_signature.xml %}

--- a/appcast/latest_unsigned.xml
+++ b/appcast/latest_unsigned.xml
@@ -1,0 +1,3 @@
+---
+---
+{% include_relative _appcast.xml %}


### PR DESCRIPTION
Sparkle 2.9 added the ability to verify appcast feeds with the developer's code signature. This adds an extra layer of security so that a supply chain / MITM attack cannot use a compromised appcast feed to show a malicious message. In order to support that, the server needs to serve signed appcasts first or the updated client will reject it.

Split the appcast feed into further components so we can add in a signed portion. We now have latest.xml (which is signed), and a new latest_unsigned.xml (which is unsigned). The latest_unsigned.xml should not be used by the client at all and is only used for development purposes, as we need an unsigned version to sign against in the publishing process. From now on every time we want to publish a new appcast or do a slight edit to the release notes we will need to remember to re-sign the appcast.

---

For reference, see https://sparkle-project.org/documentation/#signing-feeds-optional